### PR TITLE
Get a minimal end to end flow

### DIFF
--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -1,5 +1,7 @@
 require "http"
 require "json"
+require "uuid"
+require "http/params"
 
 module Twiliosim
   VERSION = "0.1.0"
@@ -16,12 +18,25 @@ class Twiliosim::Server
     @address = @server.bind_tcp host, port
 
     @nums = Array(Int32).new
+    @verboice_url = ""
   end
 
   def handle_request(context)
     request = context.request
 
     case request.path
+    when %r(.+/IncomingPhoneNumbers.+)
+      context.response.status_code = 200
+      context.response.content_type = "application/json"
+      response = {"sid" => UUID.random().to_s()}
+      context.response.puts response.to_json
+    when %r(.+/Calls.*)
+      params = HTTP::Params.parse(request.body.not_nil!.gets_to_end)
+      @verboice_url = params["Url"]
+      context.response.status_code = 201
+      context.response.content_type = "application/json"
+      response = {"sid" => UUID.random().to_s()}
+      context.response.puts response.to_json
     when %r(^/add$)
       @nums << request.query_params["num"].to_i
       context.response.status_code = 200

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -29,14 +29,14 @@ class Twiliosim::Server
       context.response.status_code = 200
       context.response.content_type = "application/json"
       response = {"sid" => UUID.random().to_s()}
-      context.response.puts response.to_json
+      response.to_json(context.response)
     when %r(.+/Calls.*)
       params = HTTP::Params.parse(request.body.not_nil!.gets_to_end)
       @verboice_url = params["Url"]
       context.response.status_code = 201
       context.response.content_type = "application/json"
       response = {"sid" => UUID.random().to_s()}
-      context.response.puts response.to_json
+      response.to_json(context.response)
     when %r(^/add$)
       @nums << request.query_params["num"].to_i
       context.response.status_code = 200


### PR DESCRIPTION
Getting a call from Verboice, simulate that Twilio received the Call request. So the respondent is considered active.

A couple of considerations:

1. The `IncomingPhoneNumbers` endpoint is called when the channel is updated.

![IncomingPhoneNumbers log](https://user-images.githubusercontent.com/39921597/97596266-4de42500-19e3-11eb-9957-e93fbae5ebbd.png)

2. Verboice doesn't validate phone numbers

![Verboice call log (active)](https://user-images.githubusercontent.com/39921597/97596104-27be8500-19e3-11eb-82b8-13ecc7bd2820.png)

![Calls log](https://user-images.githubusercontent.com/39921597/97596704-c21ec880-19e3-11eb-8a25-03feb6bd5014.png)

3. Verboice doesn't wait for the Twilio callback forever. It times out after a couple of minutes:

![Verboice call log (failed)](https://user-images.githubusercontent.com/39921597/97611931-8e4c9e80-19f5-11eb-9c9d-da2f44337af2.png)
 
Fixes #3