### PR TITLE
Add a respondent interaction model

### DIFF
--- a/src/ao_message.cr
+++ b/src/ao_message.cr
@@ -1,0 +1,12 @@
+abstract struct AOMessage
+  getter message : String
+  def initialize(@message : String)
+  end
+end
+
+struct TwilioAOMessage < AOMessage
+  getter redirect_url : String
+  def initialize(message : String, @redirect_url : String)
+    super(message)
+  end
+end

--- a/src/bad_request_exception.cr
+++ b/src/bad_request_exception.cr
@@ -1,0 +1,2 @@
+class BadRequestException < Exception
+end

--- a/src/call.cr
+++ b/src/call.cr
@@ -1,0 +1,30 @@
+abstract class Call
+  property id : String
+  property to : String
+  property from : String
+
+  def initialize(@to : String, @from : String)
+    @id = UUID.random().to_s()
+  end
+
+  abstract def start()
+  abstract def finish()
+end
+
+class TwilioCall < Call
+  property account_sid : String
+  property status : String
+
+  def initialize(to : String, from : String, @account_sid : String)
+    @status = "created"
+    super(to, from)
+  end
+
+  def start()
+    @status = "in-progress"
+  end
+
+  def finish()
+    @status = "completed"
+  end
+end

--- a/src/db.cr
+++ b/src/db.cr
@@ -1,0 +1,7 @@
+class DB
+  @calls = Hash(String, Call).new
+
+  def save_call(call : Call) : Call
+    @calls[call.id] = call
+  end
+end

--- a/src/reply_command.cr
+++ b/src/reply_command.cr
@@ -1,0 +1,17 @@
+abstract struct ReplyCommand
+  getter ao_message : AOMessage
+
+  def initialize(@ao_message)
+  end
+end
+
+struct PressDigits < ReplyCommand
+  getter digits : Int32
+
+  def initialize(ao_message, @digits)
+    super(ao_message)
+  end
+end
+
+struct HangUp < ReplyCommand
+end

--- a/src/respondent.cr
+++ b/src/respondent.cr
@@ -1,0 +1,10 @@
+class Respondent
+  def Respondent.reply_message(ao_message : AOMessage) : ReplyCommand | Nil
+    case ao_message.message
+    when "hangup"
+      HangUp.new(ao_message)
+    when /#numeric|#oneof/
+      PressDigits.new(ao_message, 1)
+    end
+  end
+end

--- a/src/respondent.cr
+++ b/src/respondent.cr
@@ -1,7 +1,7 @@
 class Respondent
   def Respondent.reply_message(ao_message : AOMessage) : ReplyCommand | Nil
     case ao_message.message
-    when "hangup"
+    when "#hangup"
       HangUp.new(ao_message)
     when /#numeric|#oneof/
       PressDigits.new(ao_message, 1)

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -93,22 +93,14 @@ class Twiliosim::Server
   end
 
   private def get_body_params(body : IO | Nil, required_params : Array) : HTTP::Params
-    unless body
-      raise BadRequestException.new("Request body is missing")
-    end
+    raise BadRequestException.new("Request body is missing") unless body
     body = body.gets_to_end
-    unless body
-      raise BadRequestException.new("Request body is missing")
-    end
-    if body.blank?
-      raise BadRequestException.new("Request body is missing")
-    end
+    raise BadRequestException.new("Request body is missing") unless body
+    raise BadRequestException.new("Request body is missing") if body.blank?
 
     params = HTTP::Params.parse(body)
     required_params.map do |req_param|
-      unless params.has_key?(req_param)
-        raise BadRequestException.new("Required param '{#{req_param}}' is missing in body")
-      end
+      raise BadRequestException.new("Required param '{#{req_param}}' is missing in body") unless params.has_key?(req_param)
     end
     params
   end

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -2,6 +2,11 @@ require "http"
 require "json"
 require "uuid"
 require "http/params"
+require "./respondent.cr"
+require "./call.cr"
+require "./ao_message.cr"
+require "./reply_command.cr"
+require "./db.cr"
 
 module Twiliosim
   VERSION = "0.1.0"
@@ -17,10 +22,10 @@ class Twiliosim::Server
     end
     @address = @server.bind_tcp host, port
 
-    @nums = Array(Int32).new
+    @db = DB.new
   end
 
-  def handle_request(context)
+  def handle_request(context : HTTP::Server::Context)
     request = context.request
 
     case request.path
@@ -31,85 +36,155 @@ class Twiliosim::Server
       response.to_json(context.response)
     when %r(/Accounts/(.+)/Calls.*)
       account_sid = $1
-      body = request.body
-      unless body
-        plain_response(context, 400, "Request body is missing")
-        return
-      end
-      body = body.gets_to_end
-      unless body
-        plain_response(context, 400, "Request body is missing")
-        return
-      end
-      if body.blank?
-        plain_response(context, 400, "Request body is missing")
-        return
-      end
-      params = HTTP::Params.parse(body)
-      unless params.has_key?("Url")
-        plain_response(context, 400, "Body param 'Url' is missing")
-        return
-      end
-      verboice_url = params["Url"]
-      unless params.has_key?("From")
-        plain_response(context, 400, "Body param 'From' is missing")
-        return
-      end
-      from = params["From"]
-      unless params.has_key?("From")
-        plain_response(context, 400, "Body param 'To' is missing")
-        return
-      end
-      to = params["To"]
-      context.response.status_code = 201
-      context.response.content_type = "application/json"
-      response = {"sid" => UUID.random().to_s()}
-      response.to_json(context.response)
-      spawn do
-        sleep 1.seconds
-        request_params = {"AccountSid" => account_sid, "From" => from, "To" => to, "CallStatus" => "in-progress"}
-        request_body = HTTP::Params.encode(request_params)
-        HTTP::Client.post(verboice_url, body: request_body) do |response|
-          response_body = response.body_io.gets
-          unless response_body
-            puts "Callback failed (body response is empty) - POST #{verboice_url} #{request_body} - #{response.status_code} - #{response.status_message}"
-            next
-          end
-          if response_body.blank?
-            puts "Callback failed (body response is empty) - POST #{verboice_url} #{request_body} - #{response.status_code} - #{response.status_message}"
-            next
-          end
-          case response_body
-          when %r(<Redirect>(.*)<\/Redirect>)
-            redirect_url = $1
-            unless redirect_url
-              puts "Callback failed (redirect url is missing) - POST #{verboice_url} #{request_body} - #{response.status_code} - #{response.status_message}"
-              next
-            end
-            if %r(<Say language="en">hangup<\/Say>).matches?(response_body)
-              spawn do
-                sleep 5.seconds
-                request_params["CallStatus"] = "completed"
-                request_body = HTTP::Params.encode(request_params)
-                HTTP::Client.post(redirect_url, body: request_body)
-              end
-            end
-          else
-            puts "Callback failed (redirect url is missing) - POST #{verboice_url} #{request_body} - #{response.status_code} - #{response.status_message}"
-            next
-          end
-        end
-      end
+      handle_call_request(context, account_sid)
     else
       plain_response(context, 404, "404 Not Found")
     end
   end
-end
 
-private def plain_response(context, code, text)
-  context.response.status_code = code
-  context.response.content_type = "text/plain"
-  context.response.puts text
+  private def handle_incoming_phone_numbers_request(context)
+    context.response.status_code = 200
+    context.response.content_type = "application/json"
+    response = {"sid" => UUID.random().to_s()}
+    response.to_json(context.response)
+  end
+
+  private def handle_call_request(context, account_sid)
+    body_params = get_body_params(context.request.body)
+
+    if (body_params["error"])
+      plain_response(context, 400, body_params["error"])
+      return
+    end
+
+    from = body_params["from"]
+    to = body_params["to"]
+    verboice_url = body_params["verboice_url"]
+
+    unless from && to && verboice_url
+      plain_response(context, 500, "Internal error getting the request params")
+      return
+    end
+
+    call = TwilioCall.new(to, from, account_sid)
+    call.start()
+    @db.save_call(call)
+    response_call_created(context, call.id)
+    spawn do
+      # We give Verboice a sec to process the response. Just in case it needs it.
+      sleep 1.seconds
+
+      # verboice_url cannot be nil, so the `not_nil!` call shouldn't be here.
+      # It's included here just because of [this Crystal compiler known issue](https://github.com/crystal-lang/crystal/issues/3093)
+      handle_created_call(verboice_url.not_nil!, call)
+    end
+  end
+
+  private def get_body_params(body)
+    unless body
+      return { "error" => "Request body is missing" }
+    end
+    body = body.gets_to_end
+    unless body
+      return { "error" => "Request body is missing" }
+    end
+    if body.blank?
+      return { "error" => "Request body is missing" }
+    end
+    params = HTTP::Params.parse(body)
+    unless params.has_key?("Url")
+      return { "error" => "Body param 'Url' is missing" }
+    end
+    verboice_url = params["Url"]
+    unless params.has_key?("From")
+      return { "error" => "Body param 'From' is missing" }
+    end
+    from = params["From"]
+    unless params.has_key?("From")
+      return { "error" => "Body param 'To' is missing" }
+    end
+    to = params["To"]
+
+    { "to" => to, "from" => from, "verboice_url" => verboice_url, "error" => nil }
+  end
+
+  private def start_call(to, from, account_sid)
+    @db.start_call(to, from, account_sid)
+  end
+
+  private def response_call_created(context, sid)
+    context.response.status_code = 201
+    context.response.content_type = "application/json"
+    response = {sid: sid}
+    response.to_json(context.response)
+  end
+
+  private def handle_created_call(verboice_url : String, call : TwilioCall) : ReplyCommand | Nil
+    reply_command = call_verboice_and_reply_message(verboice_url, call, nil)
+    return unless reply_command
+    perform_response(reply_command, call)
+  end
+
+  private def call_verboice(verboice_url, call : TwilioCall, digits : Int32 | Nil) : String | Nil
+    request_params = {"AccountSid" => call.account_sid, "From" => call.from, "To" => call.to, "CallStatus" => call.status}
+    request_params["Digits"] = digits.to_s if (digits)
+    request_body = HTTP::Params.encode(request_params)
+    HTTP::Client.post(verboice_url, body: request_body) do |response|
+      empty_body_log = "Callback failed (body response is empty) - POST #{verboice_url} #{request_body} - #{response.status_code} - #{response.status_message}"
+      response_body = response.body_io.gets
+      unless response_body
+        return
+      end
+      if response_body.blank?
+        return
+      end
+      response_body
+    end
+  end
+
+  private def parse_ao_message(response_body : String) : TwilioAOMessage | Nil
+    if %r(<Say .+>(.+)<\/Say>.*<Redirect>(.+)<\/Redirect>).match(response_body)
+      message = $1
+      redirect_url = $2
+      TwilioAOMessage.new(message, redirect_url)
+    end
+  end
+
+  private def ao_message_redirect_url(ao_message : TwilioAOMessage)
+    ao_message.redirect_url
+  end
+
+  private def perform_response(reply_command : HangUp, call : TwilioCall) : ReplyCommand | Nil
+    redirect_url = ao_message_redirect_url(reply_command.ao_message)
+    return unless redirect_url
+    call.finish()
+    @db.save_call(call)
+    reply_command = call_verboice_and_reply_message(redirect_url, call, nil)
+    return unless reply_command
+    perform_response(reply_command, call)
+  end
+
+  private def perform_response(reply_command : PressDigits, call : TwilioCall) : ReplyCommand | Nil
+    redirect_url = ao_message_redirect_url(reply_command.ao_message)
+    return unless redirect_url
+    reply_command = call_verboice_and_reply_message(redirect_url, call, reply_command.digits)
+    return unless reply_command
+    perform_response(reply_command, call)
+  end
+
+  private def call_verboice_and_reply_message(redirect_url : String, call : TwilioCall, digits : Int32 | Nil) : ReplyCommand | Nil
+    response_body = call_verboice(redirect_url, call, digits)
+    return unless response_body
+    ao_message = parse_ao_message(response_body)
+    return unless ao_message
+    Respondent.reply_message(ao_message)
+  end
+
+  private def plain_response(context, code, text)
+    context.response.status_code = code
+    context.response.content_type = "text/plain"
+    context.response.puts text
+  end
 end
 
 server = Twiliosim::Server.new("0.0.0.0", ENV.fetch("PORT", "3000").to_i)

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -125,12 +125,9 @@ class Twiliosim::Server
     request_params["Digits"] = digits.to_s if (digits)
     request_body = HTTP::Params.encode(request_params)
     HTTP::Client.post(verboice_url, body: request_body) do |response|
-      empty_body_log = "Callback failed (body response is empty) - POST #{verboice_url} #{request_body} - #{response.status_code} - #{response.status_message}"
-      response_body = response.body_io.gets
-      unless response_body
-        return
-      end
+      response_body = response.body_io.gets_to_end
       if response_body.blank?
+        puts "Callback failed (body response is empty) - POST #{verboice_url} #{request_body} - #{response.status_code} - #{response.status_message}"
         return
       end
       response_body

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -56,7 +56,7 @@ class Twiliosim::Server
         puts "BadRequestException message is missing"
         raise unknown_error_message
       end
-        plain_response(context, 400, message)
+        context.response.respond_with_status(:bad_request, message)
       return
     end
 

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -26,14 +26,9 @@ class Twiliosim::Server
   end
 
   def handle_request(context : HTTP::Server::Context)
-    request = context.request
-
-    case request.path
+    case context.request.path
     when %r(.+/IncomingPhoneNumbers.+)
-      context.response.status_code = 200
-      context.response.content_type = "application/json"
-      response = {"sid" => UUID.random().to_s()}
-      response.to_json(context.response)
+      handle_incoming_phone_numbers_request(context)
     when %r(/Accounts/(.+)/Calls.*)
       account_sid = $1
       handle_call_request(context, account_sid)

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -103,10 +103,6 @@ class Twiliosim::Server
     { "to" => to, "from" => from, "verboice_url" => verboice_url, "error" => nil }
   end
 
-  private def start_call(to, from, account_sid)
-    @db.start_call(to, from, account_sid)
-  end
-
   private def response_call_created(context, sid)
     context.response.status_code = 201
     context.response.content_type = "application/json"

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -151,17 +151,15 @@ class Twiliosim::Server
 
   private def perform_response(reply_command : HangUp, call : TwilioCall) : ReplyCommand | Nil
     redirect_url = ao_message_redirect_url(reply_command.ao_message)
-    return unless redirect_url
+    reply_command = call_verboice_and_reply_message(redirect_url, call, nil)
     call.finish()
     @db.save_call(call)
-    reply_command = call_verboice_and_reply_message(redirect_url, call, nil)
     return unless reply_command
     perform_response(reply_command, call)
   end
 
   private def perform_response(reply_command : PressDigits, call : TwilioCall) : ReplyCommand | Nil
     redirect_url = ao_message_redirect_url(reply_command.ao_message)
-    return unless redirect_url
     reply_command = call_verboice_and_reply_message(redirect_url, call, reply_command.digits)
     return unless reply_command
     perform_response(reply_command, call)

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -41,7 +41,7 @@ class Twiliosim::Server
   private def handle_incoming_phone_numbers_request(context)
     context.response.status_code = 200
     context.response.content_type = "application/json"
-    response = {"sid" => UUID.random().to_s()}
+    response = {sid: UUID.random().to_s()}
     response.to_json(context.response)
   end
 

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -166,12 +166,6 @@ class Twiliosim::Server
     return unless ao_message
     Respondent.reply_message(ao_message)
   end
-
-  private def plain_response(context : HTTP::Server::Context, code : Int32, text : String)
-    context.response.status_code = code
-    context.response.content_type = "text/plain"
-    context.response.puts text
-  end
 end
 
 server = Twiliosim::Server.new("0.0.0.0", ENV.fetch("PORT", "3000").to_i)

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -122,7 +122,7 @@ class Twiliosim::Server
 
   private def call_verboice(verboice_url, call : TwilioCall, digits : Int32 | Nil) : String | Nil
     request_params = {"AccountSid" => call.account_sid, "From" => call.from, "To" => call.to, "CallStatus" => call.status}
-    request_params["Digits"] = digits.to_s if (digits)
+    request_params["Digits"] = digits.to_s if digits
     request_body = HTTP::Params.encode(request_params)
     HTTP::Client.post(verboice_url, body: request_body) do |response|
       response_body = response.body_io.gets_to_end

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -34,7 +34,7 @@ class Twiliosim::Server
       account_sid = $1
       handle_call_request(context, account_sid)
     else
-      plain_response(context, 404, "404 Not Found")
+      context.response.respond_with_status(:not_found)
     end
   end
 

--- a/src/twiliosim.cr
+++ b/src/twiliosim.cr
@@ -6,7 +6,7 @@ require "./respondent.cr"
 require "./call.cr"
 require "./ao_message.cr"
 require "./reply_command.cr"
-require "./db.cr"
+require "./twiliosim_db.cr"
 
 module Twiliosim
   VERSION = "0.1.0"
@@ -22,7 +22,7 @@ class Twiliosim::Server
     end
     @address = @server.bind_tcp host, port
 
-    @db = DB.new
+    @db = TwiliosimDB.new
   end
 
   def handle_request(context : HTTP::Server::Context)

--- a/src/twiliosim_db.cr
+++ b/src/twiliosim_db.cr
@@ -1,7 +1,13 @@
 class TwiliosimDB
-  @calls = Hash(String, Call).new
+  @calls = Hash(String, TwilioCall).new
 
-  def save_call(call : Call) : Call
+  def create_call(to : String, from : String, @account_sid : String) : TwilioCall
+    call = TwilioCall.new(to, from, account_sid)
+    @calls[call.id] = call
+  end
+
+  def update_call(call : TwilioCall) : TwilioCall
+    raise "Cannot update an unexistent Call in DB - #{call.id}" unless @calls[call.id]
     @calls[call.id] = call
   end
 end

--- a/src/twiliosim_db.cr
+++ b/src/twiliosim_db.cr
@@ -1,4 +1,4 @@
-class DB
+class TwiliosimDB
   @calls = Hash(String, Call).new
 
   def save_call(call : Call) : Call


### PR DESCRIPTION
Before making this project bigger we must improve its code design. If we don't, we'll get off on the wrong foot.

Here we include the first respondent interaction model. So the beginnings of the code stop smelling so bad.

We're also preparing the field to make a sort of union with the sibling/ancestor [NCD local gateway simulator](https://github.com/instedd/ncd_local_gateway_simulator). This is why there are Twilio specific classes, like `TwilioCall` and `TwilioAOMessage`. 

There are three interactions supported so far:

- [x] Simulate the call is created and nothing more happens -> Verboice times out and cancels the call.
- [x] Simulate the respondent hangs up (say `#hangup` instruction received)
- [x] Simulate the respondent answers "1" (say `#oneof...` or say "#numeric" instruction received)

Fix #7